### PR TITLE
improve rabbit configuration builder pattern

### DIFF
--- a/Example/Example.Autofac/Program.cs
+++ b/Example/Example.Autofac/Program.cs
@@ -27,35 +27,35 @@ IHostBuilder CreateHostBuilder(string[] args) => Host.CreateDefaultBuilder(args)
     {
         services.AddRabbitHelper(builder =>
         {
-            builder.SetHostName("localhost");
-            builder.SetPort(5672);
-            builder.SetVirtualHost("/");
-            builder.SetUserName("admin");
-            builder.SetPassword("admin");
-            builder.AddProducerOption(producer =>
-            {
-                producer.ProducerName = "FooProducer";
-                producer.ExchangeName = "amq.topic";
-                producer.RoutingKey = "foo.key";
-                producer.Type = ExchangeType.Topic;
-            });
-            builder.AddProducerOption(producer =>
-            {
-                producer.ProducerName = "BarProducer";
-                producer.ExchangeName = "amq.direct";
-                producer.RoutingKey = "bar.key";
-                producer.Type = ExchangeType.Direct;
-            });
-            builder.AddConsumerOption(consumer =>
-            {
-                consumer.ConsumerName = "FooConsumer";
-                consumer.QueueName = "foo-queue";
-            });
-            builder.AddConsumerOption(consumer =>
-            {
-                consumer.ConsumerName = "BarConsumer";
-                consumer.QueueName = "bar-queue";
-            });
+            builder.SetHostName("localhost")
+                .SetPort(5672)
+                .SetVirtualHost("/")
+                .SetUserName("admin")
+                .SetPassword("admin")
+                .AddProducerOption(producer =>
+                {
+                    producer.ProducerName = "FooProducer";
+                    producer.ExchangeName = "amq.topic";
+                    producer.RoutingKey = "foo.key";
+                    producer.Type = ExchangeType.Topic;
+                })
+                .AddProducerOption(producer =>
+                {
+                    producer.ProducerName = "BarProducer";
+                    producer.ExchangeName = "amq.direct";
+                    producer.RoutingKey = "bar.key";
+                    producer.Type = ExchangeType.Direct;
+                })
+                .AddConsumerOption(consumer =>
+                {
+                    consumer.ConsumerName = "FooConsumer";
+                    consumer.QueueName = "foo-queue";
+                })
+                .AddConsumerOption(consumer =>
+                {
+                    consumer.ConsumerName = "BarConsumer";
+                    consumer.QueueName = "bar-queue";
+                });
         })
         .AddRabbitConsumer<FooQueueHandler>("FooConsumer", consumers: 3)
         .AddRabbitConsumer<BarQueueHandler>("BarConsumer", consumers: 2);

--- a/Src/NanoRabbit/Connection/RabbitBuilder.cs
+++ b/Src/NanoRabbit/Connection/RabbitBuilder.cs
@@ -23,70 +23,84 @@ public class RabbitConfigurationBuilder
     /// Set hostname of RabbitMQ connection.
     /// </summary>
     /// <param name="hostName"></param>
-    public void SetHostName(string hostName)
+    public RabbitConfigurationBuilder SetHostName(string hostName)
     {
         _rabbitConfiguration.HostName = hostName;
+
+        return this;
     }
 
     /// <summary>
     /// Set port of RabbitMQ amqp connection.
     /// </summary>
     /// <param name="port"></param>
-    public void SetPort(int port)
+    public RabbitConfigurationBuilder SetPort(int port)
     {
         _rabbitConfiguration.Port = port;
+
+        return this;
     }
 
     /// <summary>
     /// Set virtual host of RabbitMQ connection.
     /// </summary>
     /// <param name="virtualHost"></param>
-    public void SetVirtualHost(string virtualHost)
+    public RabbitConfigurationBuilder SetVirtualHost(string virtualHost)
     {
         _rabbitConfiguration.VirtualHost = virtualHost;
+
+        return this;
     }
 
     /// <summary>
     /// Set username of RabbitMQ connection.
     /// </summary>
     /// <param name="userName"></param>
-    public void SetUserName(string userName)
+    public RabbitConfigurationBuilder SetUserName(string userName)
     {
         _rabbitConfiguration.UserName = userName;
+
+        return this;
     }
 
     /// <summary>
     /// Set password of RabbitMQ connection.
     /// </summary>
     /// <param name="password"></param>
-    public void SetPassword(string password)
+    public RabbitConfigurationBuilder SetPassword(string password)
     {
         _rabbitConfiguration.Password = password;
+
+        return this;
     }
 
     /// <summary>
     /// Set to true will enable a asynchronous consumer dispatcher. Defaults to false.
     /// </summary>
     /// <param name="useAsyncConsumer"></param>
-    public void UseAsyncConsumer(bool useAsyncConsumer)
+    public RabbitConfigurationBuilder UseAsyncConsumer(bool useAsyncConsumer)
     {
         _rabbitConfiguration.UseAsyncConsumer = useAsyncConsumer;
+
+        return this;
     }
 
     /// <summary>
     /// Set to false will disable NanoRabbit GlobalLogger. Defaults to true.
     /// </summary>
     /// <param name="enableLogging"></param>
-    public void EnableLogging(bool enableLogging)
+    public RabbitConfigurationBuilder EnableLogging(bool enableLogging)
     {
         _rabbitConfiguration.EnableLogging = enableLogging;
+
+        return this;
     }
 
     /// <summary>
     /// Add a producer to RabbitMQ connection.
     /// </summary>
     /// <param name="configureProducer"></param>
-    public void AddProducerOption(Action<ProducerOptions> configureProducer)
+    public RabbitConfigurationBuilder AddProducerOption(Action<ProducerOptions> configureProducer)
     {
         var options = new ProducerOptions();
         configureProducer(options);
@@ -98,13 +112,15 @@ public class RabbitConfigurationBuilder
             }
             _rabbitConfiguration.Producers.Add(options);
         }
+
+        return this;
     }
 
     /// <summary>
     /// Add a consumer to RabbitMQ connection.
     /// </summary>
     /// <param name="configureConsumer"></param>
-    public void AddConsumerOption(Action<ConsumerOptions> configureConsumer)
+    public RabbitConfigurationBuilder AddConsumerOption(Action<ConsumerOptions> configureConsumer)
     {
         var options = new ConsumerOptions();
         configureConsumer(options);
@@ -116,6 +132,8 @@ public class RabbitConfigurationBuilder
             }
             _rabbitConfiguration.Consumers.Add(options);
         }
+
+        return this;
     }
 
     /// <summary>


### PR DESCRIPTION
In RabbitConfigurationBuilder class changed every method to return RabbitConfigurationBuilder instance, in this way chaining methods would be able while constructing configuration.

In Example.Autofac project also change usage of AddRabbitHelper method to use method chaining in builder.

if this approach is okay for you, I can change usage in other sample projects as well