### PR TITLE
provide logger while configuring NanoRabbit

### DIFF
--- a/Example/Example.Autofac/Program.cs
+++ b/Example/Example.Autofac/Program.cs
@@ -4,6 +4,7 @@ using Autofac.Extensions.DependencyInjection;
 using Example.Autofac;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using NanoRabbit;
 using NanoRabbit.Connection;
 
@@ -56,6 +57,15 @@ IHostBuilder CreateHostBuilder(string[] args) => Host.CreateDefaultBuilder(args)
                     consumer.ConsumerName = "BarConsumer";
                     consumer.QueueName = "bar-queue";
                 });
+        }, serviceCollection => {
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+            });
+
+            var logger = loggerFactory.CreateLogger("RabbitHelper");
+
+            return logger;
         })
         .AddRabbitConsumer<FooQueueHandler>("FooConsumer", consumers: 3)
         .AddRabbitConsumer<BarQueueHandler>("BarConsumer", consumers: 2);

--- a/Example/Example.QuickStart/Program.cs
+++ b/Example/Example.QuickStart/Program.cs
@@ -1,5 +1,13 @@
-﻿using NanoRabbit;
+﻿using Microsoft.Extensions.Logging;
+using NanoRabbit;
 using NanoRabbit.Connection;
+
+var loggerFactory = LoggerFactory.Create(builder =>
+{
+    builder.AddConsole();
+});
+
+var logger = loggerFactory.CreateLogger("RabbitHelper");
 
 var rabbitHelper = new RabbitHelper(rabbitConfig: new RabbitConfiguration
 {
@@ -19,7 +27,7 @@ var rabbitHelper = new RabbitHelper(rabbitConfig: new RabbitConfiguration
             QueueName = "foo-queue"
         }
     }
-});
+}, logger);
 
 rabbitHelper.Publish<string>("FooProducer", "Hello from NanoRabbit");
 

--- a/Src/NanoRabbit/Connection/ConnectionOptions.cs
+++ b/Src/NanoRabbit/Connection/ConnectionOptions.cs
@@ -130,6 +130,7 @@ public class RabbitConfiguration
     /// Enable logging.
     /// Defaults: true
     /// </summary>
+    [Obsolete("this will be removed in next versions. instead pass logger while configuring NanoRabbit")]
     public bool EnableLogging { get; set; } = true;
 
     /// <summary>

--- a/Src/NanoRabbit/Connection/RabbitBuilder.cs
+++ b/Src/NanoRabbit/Connection/RabbitBuilder.cs
@@ -89,6 +89,7 @@ public class RabbitConfigurationBuilder
     /// Set to false will disable NanoRabbit GlobalLogger. Defaults to true.
     /// </summary>
     /// <param name="enableLogging"></param>
+    [Obsolete("this will be removed in next versions. instead pass logger while configuring NanoRabbit")]
     public RabbitConfigurationBuilder EnableLogging(bool enableLogging)
     {
         _rabbitConfiguration.EnableLogging = enableLogging;

--- a/Src/NanoRabbit/RabbitHelper.cs
+++ b/Src/NanoRabbit/RabbitHelper.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
 using NanoRabbit.Connection;
-using NanoRabbit.Logging;
 using Newtonsoft.Json;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
@@ -18,15 +17,14 @@ namespace NanoRabbit
         private readonly Dictionary<string, EventingBasicConsumer> _consumers;
         private readonly Dictionary<string, AsyncEventingBasicConsumer> _asyncConsumers;
         private readonly RabbitConfiguration _rabbitConfig;
-        private readonly ILogger<RabbitHelper>? _logger;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// RabbitHelper constructor.
         /// </summary>
         /// <param name="rabbitConfig"></param>
         /// <param name="logger"></param>
-        public RabbitHelper(
-            RabbitConfiguration rabbitConfig, ILogger<RabbitHelper>? logger = null)
+        public RabbitHelper(RabbitConfiguration rabbitConfig, ILogger logger)
         {
             _rabbitConfig = rabbitConfig;
             ConnectionFactory factory = new();
@@ -47,23 +45,12 @@ namespace NanoRabbit
 
             if (_rabbitConfig.UseAsyncConsumer) factory.DispatchConsumersAsync = true;
 
-            if (_rabbitConfig.EnableLogging)
-            {
-                if (logger != null)
-                {
-                    _logger = logger;
-                }
-                else
-                {
-                    _logger = (ILogger<RabbitHelper>?)GlobalLogger.Logger;
-                }
-            }
-
             _connection = factory.CreateConnection();
             _channel = _connection.CreateModel();
 
             _consumers = new Dictionary<string, EventingBasicConsumer>();
             _asyncConsumers = new Dictionary<string, AsyncEventingBasicConsumer>();
+            _logger = logger;
         }
 
         /// <summary>


### PR DESCRIPTION
here is what I did you if like my solution. for me EnableLogging does not solve problem, user can't control where logs goes. On EnableLogging property and method in builder class I added Obsolute attribute, that this functionality will be removed in later versions.

my solution is to user must provide logger through configuration, in AddRabbitHelper method or others. if logger is provided than you can pass this to RabbitHelper, otherwise use NullLogger provided by Microsoft package which emits logs. so, EnableLogging property is not needed anymore.

you can check out my code.

I tested it mannualy, it you think about writing tests, this would be good place to start, we can test how injecting in DI works

feel free to reject my pr, I forgot to ask first and then write some code.