### PR TITLE
remove logger conditional access

### DIFF
--- a/Src/NanoRabbit/RabbitHelper.cs
+++ b/Src/NanoRabbit/RabbitHelper.cs
@@ -144,7 +144,7 @@ namespace NanoRabbit
 
             _channel.BasicPublish(exchange: option.ExchangeName, routingKey: option.RoutingKey, basicProperties: properties, body: body);
 
-            _logger?.LogInformation($"{producerName}|Published|{messageStr}");
+            _logger.LogInformation($"{producerName}|Published|{messageStr}");
         }
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace NanoRabbit
                             basicProperties: properties,
                             body: body);
             }
-            _logger?.LogInformation($"{producerName}|Published a batch of messgages.");
+            _logger.LogInformation($"{producerName}|Published a batch of messgages.");
         }
 
         /// <summary>


### PR DESCRIPTION
remove conditional access from logger, I mean this: ```logger?.LogInformation()```. it's not needed, logger never be null. it will be provided from user or NullLogger which logs nothing