### PR TITLE
Refactor/rabbit helper optiions methods

### DIFF
--- a/Src/NanoRabbit/RabbitHelper.cs
+++ b/Src/NanoRabbit/RabbitHelper.cs
@@ -60,7 +60,7 @@ namespace NanoRabbit
         /// </summary>
         /// <param name="producerName"></param>
         /// <returns></returns>
-        public ProducerOptions GetProducerOption(string producerName)
+        private ProducerOptions GetProducerOption(string producerName)
         {
             if (_rabbitConfig.Producers != null)
             {
@@ -85,7 +85,7 @@ namespace NanoRabbit
         /// <param name="consumerName"></param>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        public ConsumerOptions GetConsumerOption(string? consumerName)
+        private ConsumerOptions GetConsumerOption(string? consumerName)
         {
             if (_rabbitConfig.Consumers != null)
             {

--- a/Src/NanoRabbit/RabbitHelper.cs
+++ b/Src/NanoRabbit/RabbitHelper.cs
@@ -62,21 +62,13 @@ namespace NanoRabbit
         /// <returns></returns>
         private ProducerOptions GetProducerOption(string producerName)
         {
-            if (_rabbitConfig.Producers != null)
-            {
-                var connectionOption = _rabbitConfig.Producers.FirstOrDefault(o => o.ProducerName == producerName);
-
-                if (connectionOption == null)
-                {
-                    throw new Exception($"Producer '{producerName}' not found!");
-                }
-
-                return connectionOption;
-            }
-            else
-            {
+            if (_rabbitConfig.Producers == null)
                 throw new Exception("No ProducerOptions added in RabbitHelper!");
-            }
+            
+            var producerOptions = _rabbitConfig.Producers.FirstOrDefault(o => o.ProducerName == producerName)
+                ?? throw new Exception($"Producer '{producerName}' not found!");
+
+            return producerOptions;
         }
 
         /// <summary>
@@ -87,21 +79,13 @@ namespace NanoRabbit
         /// <exception cref="Exception"></exception>
         private ConsumerOptions GetConsumerOption(string? consumerName)
         {
-            if (_rabbitConfig.Consumers != null)
-            {
-                var connectionOption = _rabbitConfig.Consumers.FirstOrDefault(x => x.ConsumerName == consumerName);
-
-                if (connectionOption == null)
-                {
-                    throw new Exception($"Consumer '{consumerName}' not found!");
-                }
-
-                return connectionOption;
-            }
-            else
-            {
+            if (_rabbitConfig.Consumers == null) 
                 throw new Exception("No ConsumerOptions added in RabbitHelper!");
-            }
+            
+            var consumerOptions = _rabbitConfig.Consumers.FirstOrDefault(x => x.ConsumerName == consumerName)
+                ?? throw new Exception($"Consumer '{consumerName}' not found!");
+
+            return consumerOptions;
         }
 
         /// <summary>


### PR DESCRIPTION
I changed couple of things here.

1. GetProducerOption and GetConsumerOption methods don't need to be public, so I made them private.

2. use early return principle, check what needs to be checked and return response immediately
```
 if (_rabbitConfig.Producers == null)
                throw new Exception("No ProducerOptions added in RabbitHelper!");
```

3. used ternary operator to check nullable object return from ```FirstOrDefault``` method
```
var producerOptions = _rabbitConfig.Producers.FirstOrDefault(o => o.ProducerName == producerName)
                ?? throw new Exception($"Producer '{producerName}' not found!");
```